### PR TITLE
#72 Set up Absolute Imports and Module Path Aliases

### DIFF
--- a/veterans/app/layout.tsx
+++ b/veterans/app/layout.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { Lato, Golos_Text } from 'next/font/google';
 
-import Header from '../components/common/header/Header';
-import Banner from '../components/common/header/banner';
-import HeaderContent from '../components/common/header/HeaderContent/HeaderContent';
-import Footer from '../components/common/footer/Footer';
-import FooterContent from '../components/common/footer/FooterContent/FooterContent';
-
-import '../styles/global.css';
+import 'styles/global.css';
+import Header from '@comComps/header/Header';
+import HeaderContent from '@comComps/header/HeaderContent';
+import Banner from '@comComps/header/banner';
+import Footer from '@comComps/footer/Footer';
+import FooterContent from '@comComps/footer/FooterContent';
 
 const lato = Lato({
   weight: ['300', '400', '700'],

--- a/veterans/components/common/NavMenu/index.ts
+++ b/veterans/components/common/NavMenu/index.ts
@@ -1,0 +1,1 @@
+export { default } from './NavMenu';

--- a/veterans/components/common/container/Container.tsx
+++ b/veterans/components/common/container/Container.tsx
@@ -1,7 +1,7 @@
 import { FC, ReactElement } from 'react';
 
-import concatClassNames from '../../../helpers/concatClassNames';
 import styles from './Container.module.css';
+import concatClassNames from '@helpers/concatClassNames';
 
 interface IProps {
   children: ReactElement | ReactElement[];

--- a/veterans/components/common/customImage/CustomImage.test.tsx
+++ b/veterans/components/common/customImage/CustomImage.test.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import CustomImage from './CustomImage';
-import getImageQuality from '../../../helpers/getImageQuality';
+import getImageQuality from '@helpers/getImageQuality';
 
-jest.mock('../../../helpers/getImageQuality', () => jest.fn());
+jest.mock('@helpers/getImageQuality', () => jest.fn());
 
 describe('CustomImage Component', () => {
   it('renders correctly with provided props', () => {

--- a/veterans/components/common/customImage/CustomImage.tsx
+++ b/veterans/components/common/customImage/CustomImage.tsx
@@ -1,5 +1,5 @@
 import Image, { ImageProps } from 'next/image';
-import getImageQuality from '../../../helpers/getImageQuality';
+import getImageQuality from '@helpers/getImageQuality';
 
 interface CustomImageProps extends Omit<ImageProps, 'quality'> {
   alt: string;

--- a/veterans/components/common/footer/Footer.test.tsx
+++ b/veterans/components/common/footer/Footer.test.tsx
@@ -7,7 +7,7 @@ afterEach(() => {
   cleanup();
 });
 
-jest.mock('../container', () => ({
+jest.mock('@comComps/container', () => ({
   __esModule: true,
   default: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>

--- a/veterans/components/common/footer/Footer.tsx
+++ b/veterans/components/common/footer/Footer.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { FC } from 'react';
-import Container from '../container';
 
 import st from './Footer.module.css';
+import Container from '@comComps/container';
 
 type Props = {
   children: React.ReactElement;

--- a/veterans/components/common/footer/FooterContent/FooterContent.tsx
+++ b/veterans/components/common/footer/FooterContent/FooterContent.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { usePathname } from 'next/navigation';
-import NavMenu from '../../NavMenu/NavMenu';
-
 import st from './FooterContent.module.css';
+
+import { usePathname } from 'next/navigation';
+import NavMenu from '@comComps/NavMenu';
 
 const pages = {
   about_us: 'Про нас',

--- a/veterans/components/common/footer/FooterContent/index.ts
+++ b/veterans/components/common/footer/FooterContent/index.ts
@@ -1,0 +1,1 @@
+export { default } from './FooterContent';

--- a/veterans/components/common/header/Header.test.tsx
+++ b/veterans/components/common/header/Header.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen, act } from '@testing-library/react';
 import Header from './Header';
 
-jest.mock('../container', () => ({
+jest.mock('@comComps/container', () => ({
   __esModule: true,
   default: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>

--- a/veterans/components/common/header/Header.tsx
+++ b/veterans/components/common/header/Header.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { FC, useEffect, useRef } from 'react';
-import { throttle } from '../../../helpers/throttle';
 
 import st from './Header.module.css';
-import Container from '../container';
+import { throttle } from '@helpers/throttle';
+import Container from '@comComps/container';
 
 type Props = {
   children: React.ReactElement;

--- a/veterans/components/common/header/HeaderContent/HeaderContent.test.tsx
+++ b/veterans/components/common/header/HeaderContent/HeaderContent.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import HeaderContent from './HeaderContent';
 
-jest.mock('../Navigation/NavMain.tsx', () => () => (
+jest.mock('@comComps/header/Navigation/NavMain', () => () => (
   <div data-testid="nav-main" />
 ));
 

--- a/veterans/components/common/header/HeaderContent/HeaderContent.tsx
+++ b/veterans/components/common/header/HeaderContent/HeaderContent.tsx
@@ -1,5 +1,5 @@
-import st from '../Header.module.css';
-import Navigation from '../Navigation/Navigation';
+import st from '@comComps/header/Header.module.css';
+import Navigation from '@comComps/header/Navigation';
 
 type HeaderContentProps = {
   children: React.ReactNode;

--- a/veterans/components/common/header/HeaderContent/index.ts
+++ b/veterans/components/common/header/HeaderContent/index.ts
@@ -1,0 +1,1 @@
+export { default } from './HeaderContent';

--- a/veterans/components/common/header/Navigation/NavMain.test.tsx
+++ b/veterans/components/common/header/Navigation/NavMain.test.tsx
@@ -3,14 +3,14 @@ import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import { usePathname } from 'next/navigation';
-import { NavigationMenuProps } from '../../NavMenu/NavMenu';
 import NavMain from './NavMain';
+import { NavigationMenuProps } from '@comComps/NavMenu/NavMenu';
 
 jest.mock('next/navigation', () => ({
   usePathname: jest.fn(),
 }));
 
-jest.mock('../../NavMenu/NavMenu', () => {
+jest.mock('@comComps/NavMenu', () => {
   return jest.fn(({ pages, pathname, st }: NavigationMenuProps) => (
     <nav className={st.navContainer} aria-label="Main navigation">
       <ul className={st.navList}>

--- a/veterans/components/common/header/Navigation/NavMain.tsx
+++ b/veterans/components/common/header/Navigation/NavMain.tsx
@@ -2,7 +2,7 @@
 
 import { usePathname } from 'next/navigation';
 import st from './NavMain.module.css';
-import NavMenu from '../../NavMenu/NavMenu';
+import NavMenu from '@comComps/NavMenu';
 
 const pages = {
   goal: 'Мета',

--- a/veterans/components/common/header/Navigation/Navigation.tsx
+++ b/veterans/components/common/header/Navigation/Navigation.tsx
@@ -2,9 +2,11 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { usePathname } from 'next/navigation';
-import NavMain from './NavMain';
+
 import st from './NavMain.module.css';
-import CustomImage from '../../customImage/CustomImage';
+
+import NavMain from './NavMain';
+import CustomImage from '@comComps/customImage';
 
 type RazomProps = {
   name?: string;

--- a/veterans/components/common/header/Navigation/index.ts
+++ b/veterans/components/common/header/Navigation/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Navigation';

--- a/veterans/components/common/header/banner/Banner.test.tsx
+++ b/veterans/components/common/header/banner/Banner.test.tsx
@@ -1,11 +1,13 @@
-import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
-import Banner from './Banner';
-import CustomImage from '../../customImage';
-import { LinkProps } from 'next/link';
 import React from 'react';
 
-jest.mock('../../customImage', () =>
+import { LinkProps } from 'next/link';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+import Banner from './Banner';
+import customImage from '@comComps/customImage';
+
+jest.mock('@comComps/customImage', () =>
   jest.fn(() => <div data-testid="custom-image" />),
 );
 
@@ -20,7 +22,7 @@ jest.mock('next/link', () => {
   };
 });
 
-jest.mock('../Header.module.css', () => ({
+jest.mock('@comComps/header/Header.module.css', () => ({
   bannerContainer: 'bannerContainer',
   bannerLink: 'bannerLink',
 }));
@@ -44,7 +46,7 @@ describe('Banner Component', () => {
   it('passes correct props to CustomImage', () => {
     render(<Banner {...mockProps} />);
 
-    expect(CustomImage).toHaveBeenCalledWith(
+    expect(customImage).toHaveBeenCalledWith(
       expect.objectContaining({
         src: '/img/logo/logotype.svg',
         alt: 'logotype',

--- a/veterans/components/common/header/banner/Banner.tsx
+++ b/veterans/components/common/header/banner/Banner.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 
-import CustomImage from '../../customImage';
-import st from '../Header.module.css';
+import st from '@comComps/header/Header.module.css';
+import CustomImage from '@comComps/customImage';
 
 type RazomProps = {
   name: 'logotype';

--- a/veterans/jest.config.js
+++ b/veterans/jest.config.js
@@ -34,6 +34,11 @@ module.exports = {
   moduleNameMapper: {
     '\\.css$': 'identity-obj-proxy',
     '\\.module\\.css$': 'identity-obj-proxy',
+    '^@helpers/(.*)$': '<rootDir>/helpers/$1',
+    '^@comComps/(.*)$': '<rootDir>/components/common/$1',
+    '^@comps/(.*)$': '<rootDir>/components/$1',
+    '^keystone/context$': '<rootDir>/keystone/context',
+    '^keystone$': '<rootDir>/keystone',
   },
   testPathIgnorePatterns: ['/node_modules/', '/e2e/'],
 };

--- a/veterans/keystone/context.test.ts
+++ b/veterans/keystone/context.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as PrismaModule from '.prisma/client';
-import config from '../keystone';
+import config from 'keystone';
 
 jest.mock('@keystone-6/core/context', () => ({
   getContext: jest.fn(),
@@ -8,7 +8,7 @@ jest.mock('@keystone-6/core/context', () => ({
 
 jest.mock('.prisma/client', () => ({}));
 
-jest.mock('../keystone', () => ({}));
+jest.mock('keystone', () => ({}));
 
 describe('keystoneContext', () => {
   let originalKeystoneContext: any;

--- a/veterans/keystone/context.ts
+++ b/veterans/keystone/context.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { getContext } from '@keystone-6/core/context';
-import config from '../keystone';
+import config from 'keystone';
 // import { Context } from '.keystone/types';
 import * as PrismaModule from '.prisma/client';
 

--- a/veterans/pages/api/graphql.test.ts
+++ b/veterans/pages/api/graphql.test.ts
@@ -1,7 +1,7 @@
 import { makeExecutableSchema } from '@graphql-tools/schema';
 
 const mockWithRequest = jest.fn(() => ({ user: 'mock-user' }));
-jest.mock('../../keystone/context', () => {
+jest.mock('keystone/context', () => {
   const typeDefs = `
       type Query {
         _empty: String
@@ -19,7 +19,7 @@ jest.mock('../../keystone/context', () => {
   };
 });
 
-import { keystoneContext } from '../../keystone/context';
+import { keystoneContext } from 'keystone/context';
 import { config } from './graphql';
 
 describe('/api/graphql API handler', () => {

--- a/veterans/pages/api/graphql.ts
+++ b/veterans/pages/api/graphql.ts
@@ -2,7 +2,7 @@ import { type NextApiRequest, type NextApiResponse } from 'next';
 
 import { createYoga } from 'graphql-yoga';
 
-import { keystoneContext } from '../../keystone/context';
+import { keystoneContext } from 'keystone/context';
 
 export const config = {
   api: {

--- a/veterans/pages/api/posts.test.ts
+++ b/veterans/pages/api/posts.test.ts
@@ -2,9 +2,9 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 
 import { createMocks } from 'node-mocks-http';
 import handler from './posts';
-import { keystoneContext } from '../../keystone/context';
+import { keystoneContext } from 'keystone/context';
 
-jest.mock('../../keystone/context', () => ({
+jest.mock('keystone/context', () => ({
   keystoneContext: {
     query: {
       Post: {

--- a/veterans/pages/api/posts.ts
+++ b/veterans/pages/api/posts.ts
@@ -1,4 +1,4 @@
-import { keystoneContext } from '../../keystone/context';
+import { keystoneContext } from 'keystone/context';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 export default async function handler(

--- a/veterans/tsconfig.json
+++ b/veterans/tsconfig.json
@@ -1,5 +1,11 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@comComps/*": ["components/common/*"],
+      "@comps/*": ["components/*"],
+      "@helpers/*": ["helpers/*"]
+    },
     "jsx": "preserve",
     "target": "esnext",
     "module": "commonjs",


### PR DESCRIPTION
Changed all paths in the project from relative to absolute. Set up the necessary tsconfig and jest.config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Refactor**
	- Updated import paths across multiple components and modules to use absolute imports
	- Added module name mappings in Jest configuration for improved import resolution
	- Enhanced TypeScript configuration with custom path aliases

- **Chores**
	- Simplified import statements in various files
	- Added index files for easier component exports
	- Updated module resolution in TypeScript and Jest configurations

These changes improve code organization and import management without introducing new user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->