### PR TITLE
#168 Deselect the region by the second mouse click 

### DIFF
--- a/veterans/components/homePage/mapSection/MapSection.tsx
+++ b/veterans/components/homePage/mapSection/MapSection.tsx
@@ -53,6 +53,7 @@ export default function MapSection() {
       <UkraineMap
         selectedRegion={selectedRegion}
         setSelectedRegion={setSelectedRegion}
+        defaultRegionName={defaultRegion.name}
       />
     </section>
   );

--- a/veterans/components/homePage/mapSection/map/UkraineMap.tsx
+++ b/veterans/components/homePage/mapSection/map/UkraineMap.tsx
@@ -6,16 +6,24 @@ import st from './UkraineMap.module.css';
 
 interface UkraineMapProps {
   readonly selectedRegion?: string;
-  readonly setSelectedRegion: (region: string) => void;
+  readonly defaultRegionName: string;
+  readonly setSelectedRegion: React.Dispatch<
+    React.SetStateAction<string | undefined>
+  >;
 }
 
 export default function UkraineMap({
   selectedRegion,
+  defaultRegionName,
   setSelectedRegion,
 }: UkraineMapProps) {
   const handleRegionClick = useCallback(
-    (regionName: string) => () => setSelectedRegion(regionName),
-    [setSelectedRegion],
+    (regionName: string) => () => {
+      setSelectedRegion((prevSelectedRegion) =>
+        prevSelectedRegion === regionName ? defaultRegionName : regionName,
+      );
+    },
+    [setSelectedRegion, defaultRegionName],
   );
 
   return (


### PR DESCRIPTION
Deselect the region by the second mouse click 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved map interaction: Clicking a selected region now toggles it back to the default region.
- **Enhancements**
  - The map now consistently highlights the default region when no other region is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->